### PR TITLE
Added support for reading the long git sha1 and the current git tag.

### DIFF
--- a/example/Example.hx
+++ b/example/Example.hx
@@ -20,6 +20,8 @@ class Example
 		var date = CompileTime.buildDate();						// Equivalent of writing `new Date(2012,11,25,20,48,15);`
 		var dateAsString = CompileTime.buildDateString();		// A string saying "2012-12-25 20:48:15"
 		var gitsha = CompileTime.buildGitCommitSha();			// A string that might say '104ad4e'
+		var gitTag = CompileTime.buildGitTag();					// A string that might say 'v1.0.2' or 'v1.0.2-104ad4e'
+		var gitTagExact = CompileTime.buildGitTagExact();		// A string that might say 'v1.0.2'
 		var file = CompileTime.readFile("README.md");			// Reads the contents of README.md as a String.
 		var name="Jason", age=25;
 		var greeting = CompileTime.interpolateFile("test.txt"); // Reads the contents of test.txt, and interpolates local values, similar to single quotes

--- a/example/Example.hx
+++ b/example/Example.hx
@@ -20,8 +20,8 @@ class Example
 		var date = CompileTime.buildDate();						// Equivalent of writing `new Date(2012,11,25,20,48,15);`
 		var dateAsString = CompileTime.buildDateString();		// A string saying "2012-12-25 20:48:15"
 		var gitsha = CompileTime.buildGitCommitSha();			// A string that might say '104ad4e'
-		var gitTag = CompileTime.buildGitTag();					// A string that might say 'v1.0.2' or 'v1.0.2-104ad4e'
-		var gitTagExact = CompileTime.buildGitTagExact();		// A string that might say 'v1.0.2'
+		var gitTagDesrc = CompileTime.buildGitTagDescription();	// A string that might say 'v1.0.2' or 'v1.0.2-104ad4e'
+		var gitTag = CompileTime.buildGitTag();					// A string that might say 'v1.0.2'
 		var file = CompileTime.readFile("README.md");			// Reads the contents of README.md as a String.
 		var name="Jason", age=25;
 		var greeting = CompileTime.interpolateFile("test.txt"); // Reads the contents of test.txt, and interpolates local values, similar to single quotes

--- a/example/Example.hx
+++ b/example/Example.hx
@@ -20,6 +20,7 @@ class Example
 		var date = CompileTime.buildDate();						// Equivalent of writing `new Date(2012,11,25,20,48,15);`
 		var dateAsString = CompileTime.buildDateString();		// A string saying "2012-12-25 20:48:15"
 		var gitsha = CompileTime.buildGitCommitSha();			// A string that might say '104ad4e'
+		var gitshaLong = CompileTime.buildGitCommitShaLong();	// A string that might say '104ad4e8128dd7fae6d3f1c8a066e3570db99b2e'
 		var gitTagDesrc = CompileTime.buildGitTagDescription();	// A string that might say 'v1.0.2' or 'v1.0.2-104ad4e'
 		var gitTag = CompileTime.buildGitTag();					// A string that might say 'v1.0.2'
 		var file = CompileTime.readFile("README.md");			// Reads the contents of README.md as a String.

--- a/src/CompileTime.hx
+++ b/src/CompileTime.hx
@@ -49,6 +49,31 @@ class CompileTime
         return toExpr(sha1);
     }
 
+    /** Returns a string of the current git tag.
+        If there is no tag on the current commit, a combination of `TAG-SHA1` from the latest tag is returned instead.
+        If there are no tags on the repository, `null` is returned instead. */
+    macro public static function buildGitTag():ExprOf<String> {
+        var proc = new sys.io.Process('git', ['describe', '--tags']);
+        var tag = null;
+        try {
+            tag = proc.stdout.readLine();
+        }
+        catch (e: Dynamic) { }
+        return toExpr(tag);
+    }
+
+    /** Returns a string of the current git tag.
+        If there is no tag on the current commit, `null` is returned instead. */
+    macro public static function buildGitTagExact():ExprOf<String> {
+        var proc = new sys.io.Process('git', ['describe', '--tags', '--exact-match' ]);
+        var tag = null;
+        try {
+            tag = proc.stdout.readLine();
+        }
+        catch (e: Dynamic) { }
+        return toExpr(tag);
+    }
+
     /** Reads a file at compile time, and inserts the contents into your code as a string.  The file path is resolved using `Context.resolvePath`, so it will search all your class paths */
     macro public static function readFile(path:String):ExprOf<String> {
         return toExpr(loadFileAsString(path));

--- a/src/CompileTime.hx
+++ b/src/CompileTime.hx
@@ -49,6 +49,13 @@ class CompileTime
         return toExpr(sha1);
     }
 
+    /** Returns a string of the current git full sha1 */
+    macro public static function buildGitCommitShaLong():ExprOf<String> {
+        var proc = new sys.io.Process('git', ['log', "--pretty=format:'%H'", '-n', '1']);
+        var sha1 = proc.stdout.readLine();
+        return toExpr(sha1);
+    }
+
     /** Returns a string of the current git tag description.
         If there is a tag on the current commit, the tag is returned.
         If there is no tag on the current commit, a combination of `TAG-SHA1` from the latest tag is returned instead.

--- a/src/CompileTime.hx
+++ b/src/CompileTime.hx
@@ -49,10 +49,11 @@ class CompileTime
         return toExpr(sha1);
     }
 
-    /** Returns a string of the current git tag.
+    /** Returns a string of the current git tag description.
+        If there is a tag on the current commit, the tag is returned.
         If there is no tag on the current commit, a combination of `TAG-SHA1` from the latest tag is returned instead.
         If there are no tags on the repository, `null` is returned instead. */
-    macro public static function buildGitTag():ExprOf<String> {
+    macro public static function buildGitTagDescription():ExprOf<String> {
         var proc = new sys.io.Process('git', ['describe', '--tags']);
         var tag = null;
         try {
@@ -64,7 +65,7 @@ class CompileTime
 
     /** Returns a string of the current git tag.
         If there is no tag on the current commit, `null` is returned instead. */
-    macro public static function buildGitTagExact():ExprOf<String> {
+    macro public static function buildGitTag():ExprOf<String> {
         var proc = new sys.io.Process('git', ['describe', '--tags', '--exact-match' ]);
         var tag = null;
         try {


### PR DESCRIPTION
Hello!

I have implemented three new methods.

---

```haxe
var longSha1: String = CompileTime.buildGitCommitShaLong();
```

Similar to `buildGitCommitSha()`, but returns the full sha1 instead of the shorter version.

---

```haxe
var tagDescr: String = CompileTime.buildGitTagDescription();
```

Returns the output of: `git describe --tags`

Will either be the current tag (e.g `v1.0.2`) or the latest tag with the short sha1 (e.g `v1.0.2-104ad4e`).

---

```haxe
var tag: String = Compiletime.buildGitTag();
```

Returns the output of: `git describe --tags --exact-match`

Will either be the current tag or `null`.

