### PR TITLE
Adds support for loading a file as a base64 encoded string.

### DIFF
--- a/src/CompileTime.hx
+++ b/src/CompileTime.hx
@@ -54,6 +54,11 @@ class CompileTime
         return toExpr(loadFileAsString(path));
     }
 
+    /** Reads a file's bytes at compile time, and inserts the contents into your code as a Base64 encoded string.  The file path is resolved using `Context.resolvePath`, so it will search all your class paths */
+    macro public static function readFileAsBase64(path:String):ExprOf<String> {
+        return toExpr(loadFileAsBase64(path));
+    }
+
     /** Reads a file at compile time, and inserts the contents into your code as an interpolated string, similar to using 'single $quotes'.  */
     macro public static function interpolateFile(path:String):ExprOf<String> {
         return Format.format( toExpr(loadFileAsString(path)) );
@@ -160,6 +165,18 @@ class CompileTime
                 var p = Context.resolvePath(path);
                 Context.registerModuleDependency(Context.getLocalModule(),p);
                 return sys.io.File.getContent(p);
+            }
+            catch(e:Dynamic) {
+                return haxe.macro.Context.error('Failed to load file $path: $e', Context.currentPos());
+            }
+        }
+
+        static function loadFileAsBase64(path:String) {
+            try {
+                var p = Context.resolvePath(path);
+                Context.registerModuleDependency(Context.getLocalModule(),p);
+                var file = sys.io.File.getBytes(p);
+                return haxe.crypto.Base64.encode(file);
             }
             catch(e:Dynamic) {
                 return haxe.macro.Context.error('Failed to load file $path: $e', Context.currentPos());


### PR DESCRIPTION
I needed this functionality for loading some .png files at compile time. 

Helper Macro I'm using that relies on compiletime:
```
class ImageHelper {
    #if java
    public static function imageFromBase64(base64: String) {
        var decoder = Base64.getDecoder();
        return new ByteArrayInputStream(decoder.decode(base64)); 
    }
    #end
 
    macro public static function load(path: String): ExprOf<String> {
        return  macro {
              ImageHelper.imageFromBase64(CompileTime.readFileAsBase64($v{path}));
        };
    }
}
```
Actual usage:
```
public function loadAll(display: Display) {
        Bold =          new Image(display, ImageHelper.load("images/format-bold.png"));
        Italic =        new Image(display, ImageHelper.load("images/format-italic.png"));
        Underline =     new Image(display, ImageHelper.load("images/format-underline.png"));
        Strikeout =     new Image(display, ImageHelper.load("images/format-strikethrough-variant.png"));
    }
```